### PR TITLE
Readd Dashboard Tags to mlt.json

### DIFF
--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -764,7 +764,10 @@
   "refresh": "5s",
   "revision": 1,
   "schemaVersion": 38,
-  "tags": [],
+  "tags": [
+    "intro-to-mlt",
+    "mythical-beasts"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
Readd Dashboard Tags to mlt.json, so Dashboard Links work as expected again.