### PR TITLE
Add tail sampling configuration for Grafana Agent and OTel Collector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ In this example environment, Grafana Agent:
 * Receives trace data, via trace configs, emitted by the microservice application.
 * Generates automatic logging lines based on the trace data received.
 * Sends metric, log and trace data onwards to the Mimir, Loki and Tempo services, respectively.
+* Has optional (unused by default) configurations for metrics generation and trace tail sampling.
 
 Grafana Agent implements a graph-based configuration via it's Flow architecuture, using a programatic language, River, to define Grafana Agent functionality.
 

--- a/agent/config.river
+++ b/agent/config.river
@@ -91,6 +91,9 @@ otelcol.receiver.otlp "otlp_receiver" {
     // named 'default'.
     output {
         traces = [
+            // The following would be used for tail sampling only traces containing errors.
+            // Uncomment the following line, then comment out the line below it to use tail sampling.
+            //otelcol.processor.tail_sampling.errors.input,
             otelcol.processor.batch.default.input,
             otelcol.connector.spanlogs.autologging.input,
         ]
@@ -185,6 +188,50 @@ loki.write "autologging" {
     // Output the Loki log to the local Loki instance.
     endpoint {
         url = "http://loki:3100/loki/api/v1/push"
+    }
+}
+
+// The Tail Sampling processor will use a set of policies to determine which received traces to keep
+// and send to Tempo.
+otelcol.processor.tail_sampling "errors" {
+    // Total wait time from the start of a trace before making a sampling decision. Note that smaller time
+    // periods can potentially cause a decision to be made before the end of a trace has occurred.
+    decision_wait = "30s"
+
+    // The following policies follow a logical OR pattern, meaning that if any of the policies match,
+    // the trace will be kept. For logical AND, you can use the `and` policy. Every span of a trace is
+    // examined by each policy in turn. A match will cause a short-circuit.
+
+    // This policy defines that traces that contain errors should be kept.
+    policy {
+        // The name of the policy can be used for logging purposes.
+        name = "sample-erroring-traces"
+        // The type must match the type of policy to be used, in this case examing the status code
+        // of every span in the trace.
+        type = "status_code"
+        // This block determines the error codes that should match in order to keep the trace,
+        // in this case the OpenTelemetry 'ERROR' code.
+        status_code {
+            status_codes = [ "ERROR" ]
+        }
+    }
+
+    // This policy defines that only traces that are longer than 200ms in total should be kept.
+    policy {
+        // The name of the policy can be used for logging purposes.
+        name = "sample-long-traces"
+        // The type must match the policy to be used, in this case the total latency of the trace.
+        type = "latency"
+        // This block determines the total length of the trace in milliseconds.
+        latency {
+            threshold_ms = 200
+        }
+    }
+
+    // The output block forwards the kept traces onto the batch processor, which will marshall them
+    // for exporting to Tempo.
+    output {
+        traces = [otelcol.processor.batch.default.input]
     }
 }
 

--- a/otel/otel.yml
+++ b/otel/otel.yml
@@ -99,6 +99,27 @@ processors:
   #    virtual_node_peer_attributes:
   #      - db.name
 
+  # The tail sampler processor will only keep traces where spans match the defined policies.
+  tail_sampling:
+    decision_wait: 30s    # The time to wait for a decision to be made.
+    # The following policies follow a logical OR pattern, meaning that if any of the policies match,
+    # the trace will be kept. For logical AND, you can use the `and` policy. Every span of a trace is
+    # examined by each policy in turn. A match will cause a short-circuit.
+    policies: [
+      # This policy defines that traces that include spans that contain errors should be kept.
+      {
+        name: sample-erroring-traces,           # Name of the policy.
+        type: status_code,                      # The type must match the type of policy to be used.
+        status_code: { status_codes: [ERROR] }  # Only sample traces which have a span containing an error.
+      },
+      # This policy defines that traces that are over 200ms should be sampled.
+      {
+        name: sample-long-traces,               # Name of the policy.
+        type: latency,                          # The type must match the type of policy to be used.
+        latency: { threshold_ms: 200 },         # Only sample traces which are longer than 200ms in duration.
+      },
+    ]
+
 # Define exporters to data stores.
 # See https://opentelemetry.io/docs/collector/configuration/#exporters
 # Also see https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors
@@ -129,7 +150,9 @@ service:
       receivers: [otlp]
       # Use the `batch` processor to process received trace spans.
       processors: [batch]
-      # Comment out the previous line and uncomment the line below to generate span metrics and service graph metrics
+      # Comment out other `processor` definitions and uncomment the line below to use tail sampling.
+      #processors: [tail_sampling, batch]
+      # Comment out other `processor` definitions and uncomment the line below to generate span metrics and service graph metrics
       # from within the OpenTelemetry Collector.
       #processors: [spanmetrics, servicegraph, batch]
       # Export to the `otlp/grafana` exporter.


### PR DESCRIPTION
These configurations are not used by default, and require small changes to the configuration files to use them. See comments included in the configs for more details.