### PR TITLE
Updated the k8s manifest to remove server readiness probe.

### DIFF
--- a/k8s/mythical/mythical-beasts-deployment.yaml
+++ b/k8s/mythical/mythical-beasts-deployment.yaml
@@ -111,15 +111,6 @@ spec:
         ports:
         - containerPort: 4000
           protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /health
-            port: 4000
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
         resources:
           limits:
             cpu: "0.5"


### PR DESCRIPTION
On code update, this will be re-instated. These manifests work correctly and have been tested wth reference to the GET docs.