### PR TITLE
fix: tempo data source not found

### DIFF
--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -13,22 +13,22 @@ datasources:
           name: traceId
           url: '$${__value.raw}'
 
-  #- name: Tempo
-  #  type: tempo
-  #  access: proxy
-  #  uid: tempo
-  #  url: http://tempo:3200
-  #  jsonData:
-  #    nodeGraph:
-  #      enabled: true
-  #    serviceMap:
-  #      datasourceUid: 'Mimir'
-  #    tracesToLogs:
-  #      datasourceUid: loki
-  #      filterByTraceID: false
-  #      spanEndTimeShift: "500ms"
-  #      spanStartTimeShift: "-500ms"
-  #      tags: ['beast']
+  - name: Tempo
+    type: tempo
+    access: proxy
+    uid: tempo
+    url: http://tempo:3200
+    jsonData:
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: 'Mimir'
+      tracesToLogs:
+        datasourceUid: loki
+        filterByTraceID: false
+        spanEndTimeShift: "500ms"
+        spanStartTimeShift: "-500ms"
+        tags: ['beast']
 
   - name: Mimir
     type: prometheus


### PR DESCRIPTION
The removed tempo DS is causing an issue on the `MLT Erroring Endpoints` dashboard. This PR uncomments the remarked tempo DS in the configuration file.

![Screenshot 2024-02-02 031703](https://github.com/grafana/intro-to-mltp/assets/982868/d0b9a3bc-f50c-4f3b-b1d2-ca89ed6e2a8c)
