### PR TITLE
Spiky graphs and local blocks config

### DIFF
--- a/source/mythical-beasts-requester/index.js
+++ b/source/mythical-beasts-requester/index.js
@@ -176,10 +176,28 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
         requestSpan.end();
     });
 
+    // The following awful code creates spikes in the request rate which makes for more interesting graphs
+    // Joe Elliott did not write this. Do not check the blame.
+    counter++;
+    if (counter >= 3000) {
+      counter = 0;
+    }
+
+    var nextReqIn;
+    if (counter < 2000) {
+        // Choose low values in the first minute of every 5-minute interval
+        nextReqIn =  Math.floor(Math.random() * 50); 
+      } else {
+        // Choose high values for the next 4 minutes
+        nextReqIn = Math.floor(Math.random() * 1000) + 100; 
+      }
+
     // Sometime in the next two seconds, but larger than 100ms
-    const nextReqIn = (Math.random() * 1000) + 100;
+    //const nextReqIn = (Math.random() * 1000) + 100;
     setTimeout(() => makeRequest(tracingObj, sendMessage, logEntry), nextReqIn);
 };
+
+let counter = 0;
 
 (async () => {
     const tracingObj = await tracingUtils();

--- a/tempo/tempo.yaml
+++ b/tempo/tempo.yaml
@@ -58,6 +58,9 @@ storage:
 metrics_generator:
   # Specifies which processors to use.
   processor:
+    # keep all spans in the local blocks. this will allow for traceql metrics using structural queries
+    local_blocks:
+      filter_server_spans: false
     # Span metrics create metrics based on span type, duration, name and service.
     span_metrics:
         # Configure extra dimensions to add as metric labels.


### PR DESCRIPTION
Two changes. I forgive you for refusing the spiky graphs one.

The first creates some spikiness in the graphs which can provide for more interesting data to view.

![image](https://github.com/grafana/intro-to-mltp/assets/2272392/08f87711-9055-417f-83d7-965d0d2fc930)

The second forces the local blocks processor to store all spans which makes traceql metrics accurate.

Technically traceql metrics won't work until Grafana 10.4 and Tempo 2.4 but this will set things up for when the code catches up.