### PR TITLE
Update `mythical-beasts-requester/index.js` to Prefix Endpoint with a `/`

### DIFF
--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -353,7 +353,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (http_status_code,http_target,service_version)(increase(traces_spanmetrics_calls_total{http_status_code=~\"${httpStatus}\",http_target=~\"\\\\/${httpEndpoint}\"}[10m]))",
+          "expr": "sum by (http_status_code,http_target,service_version)(increase(traces_spanmetrics_calls_total{http_status_code=~\"${httpStatus}\",http_target=~\"${httpEndpoint}\"}[10m]))",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -831,7 +831,7 @@
           "type": 1
         },
         "refresh": 2,
-        "regex": "/^\\/(beholder|unicorn|manticore|illithid|owlbear).*/",
+        "regex": "/^(\\/beholder|\\/unicorn|\\/manticore|\\/illithid|\\/owlbear).*/",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"

--- a/source/mythical-beasts-requester/index.js
+++ b/source/mythical-beasts-requester/index.js
@@ -54,7 +54,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
         links: (previousReqSpanContext) ? [{ context: previousReqSpanContext }] : undefined,
     });
     requestSpan.setAttribute(spanTag, endpoint);
-    requestSpan.setAttribute(`http.target`, endpoint);
+    requestSpan.setAttribute(`http.target`, '/' + endpoint);
     requestSpan.setAttribute(`http.method`, type);
     requestSpan.setAttribute('service.version', (Math.floor(Math.random() * 100)) < 50 ? '1.9.2' : '2.0.0');
     previousReqSpanContext = requestSpan.spanContext();


### PR DESCRIPTION
Update `mythical-beasts-requester/index.js` to Prefix Endpoint with a `/`, so that Trace Metrics have a consistent `http.target` value.

Currently some are `/beast` and others are `beast`, which gives conflicting results.

Example;

![image](https://github.com/grafana/intro-to-mltp/assets/102023327/251bbb7b-7cc6-40c2-9107-c551458d205f)

For Mythical Server;

![image](https://github.com/grafana/intro-to-mltp/assets/102023327/ba4803d1-2170-4c1e-812d-60c3f2e1d05d)

I don't believe this has a wider impact to the Traces or Metrics produced, but this may need verifying.

This may need some discussion to understand whats expected and similar, or if there is an intentional reason for this.