### PR TITLE
Add configurable errors and mythical server

### DIFF
--- a/source/mythical-beasts-requester/index.js
+++ b/source/mythical-beasts-requester/index.js
@@ -63,6 +63,12 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
     // Increment the danger level on the gauge
     dangerGauge.inc(dangerLevel);
 
+    let serverHostPort = "mythical-server:4000"
+    // check env var for override
+    if (process.env.MYTHICAL_SERVER_HOST_PORT) {
+        serverHostPort = process.env.MYTHICAL_SERVER_HOST_PORT
+    }
+
     // Create a new context for this request
     api.context.with(api.trace.setSpan(api.context.active(), requestSpan), async () => {
         const start = Date.now();
@@ -74,7 +80,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
             try {
                 const result = await request({
                     method: 'GET',
-                    uri: `http://mythical-server:4000/${endpoint}`,
+                    uri: `http://${serverHostPort}/${endpoint}`,
                     headers
                 });
                 sendMessage(`GET /${endpoint}`);
@@ -94,7 +100,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
                     if (names.length > 0) {
                         await request({
                             method: 'DELETE',
-                            uri: `http://mythical-server:4000/${endpoint}`,
+                            uri: `http://${serverHostPort}/${endpoint}`,
                             json: true,
                             headers,
                             body: { name: names[0].name },
@@ -129,7 +135,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
             try {
                 await request({
                     method: 'POST',
-                    uri: `http://mythical-server:4000/${endpoint}`,
+                    uri: `http://${serverHostPort}/${endpoint}`,
                     json: true,
                     headers,
                     body,

--- a/source/mythical-beasts-server/index.js
+++ b/source/mythical-beasts-server/index.js
@@ -230,10 +230,15 @@ const logUtils = require('./logging')('mythical-server', 'server');
         }
         // POST a new unicorn name
         try {
+            let name = req.body.name
+            if (process.env.ALWAYS_SUCCEED != "true" && Math.random() < 0.1) {
+                name = null
+            }
+
             await databaseAction({
                 method: Database.POST,
                 table: endpoint,
-                name: (Math.random() < 0.1) ? null : req.body.name,
+                name: name,
             });
 
             // Metrics


### PR DESCRIPTION
Changes to allow intro-to-mltp to be used to generate local data during tracing app development. We would like to run two sets of the requester/server combo. One that is failing in cluster "A" and one succeeding in cluster "B". These changes will allow us to locally run the desired setup.