### PR TITLE
Regex update

### DIFF
--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -831,7 +831,7 @@
           "type": 1
         },
         "refresh": 2,
-        "regex": "/^(\\/beholder|\\/unicorn|\\/manticore|\\/illithid|\\/owlbear).*/",
+        "regex": "/^(\beholder|\unicorn|\manticore|\illithid|\owlbear).*/",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"


### PR DESCRIPTION
Eliminating the forward slash in the regex so the variables correctly populate in the dashboard.  Currently there are two sets of endpoints, ones with a "/" and ones without.  The ones without also have a label for service version, allowing the dashboards to populate correctly.