### PR TITLE
Fix Loki expr in Dashboard to match job "alloy"

### DIFF
--- a/cloud/dashboard-metrics-logs-traces-1.json
+++ b/cloud/dashboard-metrics-logs-traces-1.json
@@ -804,7 +804,7 @@
             "type": "loki",
             "uid": "${DS_GRAFANACLOUD-EXAMPLE1-LOGS}"
           },
-          "expr": "{job=\"agent\"} | logfmt | status=\"STATUS_CODE_ERROR\"",
+          "expr": "{job=\"alloy\"} | logfmt | status=\"Error\"",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
The panel "**Autologged Errors**" expression for Loki mismatch the configured *job_name* in *config.alloy*

Matching correction : 

> config.alloy (l.75)
```
job_name = "alloy"
```

> cloud/dashboard-metrics-logs-traces-1.json (l.807)
```
"expr": "{job=\"alloy\"} | logfmt | status=\"Error\""
```