### PR TITLE
Updates to latest version of Grafana components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Once the Docker Compose project is running, you can see examples of traces that 
 
 ### Grafana Alloy
 
-**Note:** We have now moved to a default of a Flow/River configuration, due to parity with static mode (as well as more advanced functionality).
+**Note:** We have now moved to a default of an Alloy configuration and removed the prior static config.
 
 Grafana Alloy is a Grafana distribution of the OpenTelemetry collector, receiving metrics, logs and traces and forwarding them to relevant database stores. For more details about Grafana Alloy, read the [documentation](https://grafana.com/docs/alloy/latest/).
 
@@ -241,15 +241,15 @@ In this example environment, Grafana Alloy:
 * Sends metric, log and trace data onwards to the Mimir, Loki and Tempo services, respectively.
 * Has optional (unused by default) configurations for metrics generation and trace tail sampling.
 
-Grafana Alloy implements a graph-based configuration via it's Flow architecture, using a programmatic language, River, to define Grafana Alloy functionality.
+Grafana Alloy implements a graph-based configuration via a programatic language, to define the functionality required.
 
-Once running, you can observe the Flow configuration running on the Grafana Alloy itself by navigating to [http://localhost:12347](http://localhost:12347). This webpage will allow you to view all of the current components being used for receiving MLT signals, as well as graphs denoting source and target relationships between components.
+Once running, you can observe the configuration running on the Grafana Alloy itself by navigating to [http://localhost:12347](http://localhost:12347). This webpage will allow you to view all of the current components being used for receiving MLT signals, as well as graphs denoting source and target relationships between components.
 
-The full configuration for Grafana Alloy can be found [here](alloy/config.river).
+The full configuration for Grafana Alloy can be found [here](alloy/config.alloy).
 
 Read the [Debugging](https://grafana.com/docs/alloy/latest/flow/monitoring/debugging/) documentation for Grafana Alloy for more details.
 
-The [tutorial](https://grafana.com/docs/alloy/latest/flow/tutorials/) guide to working with Flow and River is a great first starting point, whilst the full [reference guide](https://grafana.com/docs/alloy/latest/flow/reference/) for Flow shows the currently supported components and configuration blocks.
+The [tutorial](https://grafana.com/docs/alloy/latest/get-started/configuration-syntax/) guide to working with Alloy's configuration language is a great first starting point, whilst the full [reference guide](https://grafana.com/docs/alloy/latest/reference/) for shows the currently supported components and configuration blocks.
 
 Note that as Grafana Alloy scrapes metrics for every service defined in the [`docker-compose.yml`](docker-compose.yml) that a significant number of metric [active series](https://grafana.com/docs/grafana-cloud/billing-and-usage/active-series-and-dpm/) are produced (approximately 11,000 at time of writing).
 
@@ -288,6 +288,8 @@ The [`requester`](source/mythical-beasts-requester/index.js) service makes 'rand
 All three services use common code to deal with the [`queue`](source/common/queue.js), [`logging`](source/common/logging.js) and [`tracing`](source/common/tracing.js) requirements they have. The latter is an example of a simple shim API library for utilising the OpenTelemetry SDK in an application.
 
 There is a common [`Dockerfile`](source/docker/Dockerfile) that is used to build all three services.
+
+An example pipeline stage in Alloy to rewrite timestamps can be enabled by uncommenting the `TIMESHIFT` environment variable for the `mythical-requester` service. See details in the [Alloy configuration file](alloy/config.alloy).
 
 ## "NoQL" Exploration
 

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -107,12 +107,41 @@ prometheus.remote_write "mimir" {
 ///////////////////////////////////////////////////////////////////////////////
 // Logging
 
+// The Loki receiver is used to ingest logs from the mythical application via Loki's HTTP REST API.
 loki.source.api "mythical" {
+    // Listen for Loki data on port 3100.
     http {
         listen_address = "0.0.0.0"
         listen_port = "3100"
     }
 
+    // Forward all received data to the Loki processor component.
+    forward_to = [loki.process.mythical.receiver]
+}
+
+// The Loki processor allows us to accept a correctly formatted Loki log and to run a series of pipeline stages on it.
+// This particular example shows how to parse timestamp data within a logline and use it as the timestamp for the logline.
+// It essentially does nothing if the `TIMESHIFT` variable for the `mythical-requester` service is not set to `true` in
+// the relevant Docker Compose manifest.
+loki.process "mythical" {
+    // There are other stages that could easily extract the value from the logline (such as the logfmt stage), but this
+    // showcases a more complex manual regexp to extract the value into the map.
+    stage.regex {
+        expression=`^.*?loggedtime=(?P<loggedtime>\S+)`
+    }
+
+    // Use the timestamp stage to take the extracted value, now in the map, and use it as the timestamp for the logline.
+    // By doing so, you can ensure that logs that have reached Alloy at a later time than originally emitted are
+    // corrected to use the correct time, instead of the time they were received by Alloy.
+    // This stage shows an example of a user-defined timestamp format (note that the specific time the format is
+    // declared in is important for Alloy to understand the format correctly). We could also have used the RFC3339
+    // identifier in this case.
+    stage.timestamp {
+        source = "loggedtime"
+        format = "2006-01-02T15:04:05.000Z07:00"
+    }
+
+    // Forward to the Loki writer for output.
     forward_to = [loki.write.mythical.receiver]
 }
 

--- a/docker-compose-cloud.yml
+++ b/docker-compose-cloud.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+name: grafana-intro-to-mltp-cloud
 volumes:
   grafana:
   postgres:
@@ -7,7 +7,7 @@ services:
   # auto-logs from those traces.
   # Includes Metrics, Logs, Traces and Profiles.
   alloy:
-    image: grafana/alloy:v1.1.0
+    image: grafana/alloy:v1.3.1
     ports:
       - "12347:12345"
       - "12348:12348"

--- a/docker-compose-otel.yml
+++ b/docker-compose-otel.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+name: grafana-intro-to-mltp-otel
 volumes:
   grafana:
   postgres:
@@ -17,7 +17,7 @@ services:
 
   # The Grafana dashboarding server.
   grafana:
-    image: grafana/grafana:11.0.0
+    image: grafana/grafana:11.1.4
     volumes:
       - "./grafana/definitions:/var/lib/grafana/dashboards"
       - "./grafana/provisioning:/etc/grafana/provisioning"
@@ -127,7 +127,7 @@ services:
   # The Tempo service stores traces send to it by Grafana opentelemetry-collector, and takes
   # queries from Grafana to visualise those traces.
   tempo:
-    image: grafana/tempo:2.4.1
+    image: grafana/tempo:2.5.0
     ports:
       - "3200:3200"
       - "4317:4317"
@@ -141,7 +141,7 @@ services:
   # The Loki service stores logs sent to it, and takes queries from Grafana
   # to visualise those logs.
   loki:
-    image: grafana/loki:3.0.0
+    image: grafana/loki:3.1.1
     command: ["--pattern-ingester.enabled=true", "-config.file=/etc/loki/loki.yaml"]
     ports:
       - "3100:3100"
@@ -149,7 +149,7 @@ services:
       - "./loki/loki.yaml:/etc/loki/loki.yaml"
 
   mimir:
-    image: grafana/mimir:2.12.0
+    image: grafana/mimir:2.13.0
     command: ["-ingester.native-histograms-ingestion-enabled=true", "-config.file=/etc/mimir.yaml"]
     ports:
       - "9009:9009"
@@ -169,7 +169,7 @@ services:
     command: ["run", "-o", "experimental-prometheus-rw", "/scripts/mythical-loadtest.js"]
 
   beyla-requester:
-    image: grafana/beyla:1.5.3
+    image: grafana/beyla:1.7.0
     # Beyla requires to be run in the same process namespace as the process it's watching.
     # In Docker, we can do this by joining the namespace for the watched process with the Beyla
     # container watching it by using a specific `pid` label.
@@ -207,7 +207,7 @@ services:
         condition: service_started
 
   beyla-server:
-    image: grafana/beyla:1.5.3
+    image: grafana/beyla:1.7.0
     # Beyla requires to be run in the same process namespace as the process it's watching.
     # In Docker, we can do this by joining the namespace for the watched process with the Beyla
     # container watching it by using a specific `pid` label.
@@ -245,7 +245,7 @@ services:
         condition: service_started
 
   beyla-recorder:
-    image: grafana/beyla:1.5.3
+    image: grafana/beyla:1.7.0
     # Beyla requires to be run in the same process namespace as the process it's watching.
     # In Docker, we can do this by joining the namespace for the watched process with the Beyla
     # container watching it by using a specific `pid` label.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+name: grafana-intro-to-mltp
 volumes:
   grafana:
   postgres:
@@ -7,7 +7,7 @@ services:
   # auto-logs from those traces.
   # Includes Metrics, Logs, Traces and Profiles.
   alloy:
-    image: grafana/alloy:v1.1.0
+    image: grafana/alloy:v1.3.1
     ports:
       - "12347:12345"
       - "12348:12348"
@@ -25,7 +25,7 @@ services:
 
   # The Grafana dashboarding server.
   grafana:
-    image: grafana/grafana:11.0.0
+    image: grafana/grafana:11.1.4
     volumes:
       - "./grafana/definitions:/var/lib/grafana/dashboards"
       - "./grafana/provisioning:/etc/grafana/provisioning"
@@ -85,6 +85,9 @@ services:
       - TRACING_COLLECTOR_PORT=4317
       - OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
       - OTEL_RESOURCE_ATTRIBUTES=ip=1.2.3.4
+      # Uncomment this line to enable timeshift example in the mythical-requester service, which will use timestamps
+      # in the log lines themselves to rewrite the default timestamp to the time specified in the logline.
+      #- TIMESHIFT=true
 
   # The API server microservice.
   # It writes logs directly to the Loki service, exposes metrics for the Prometheus
@@ -135,7 +138,7 @@ services:
   # The Tempo service stores traces send to it by Grafana Alloy, and takes
   # queries from Grafana to visualise those traces.
   tempo:
-    image: grafana/tempo:2.4.1
+    image: grafana/tempo:2.5.0
     ports:
       - "3200:3200"
       - "4317:4317"
@@ -151,7 +154,7 @@ services:
   # The Loki service stores logs sent to it, and takes queries from Grafana
   # to visualise those logs.
   loki:
-    image: grafana/loki:3.0.0
+    image: grafana/loki:3.1.1
     command: ["--pattern-ingester.enabled=true", "-config.file=/etc/loki/loki.yaml"]
     ports:
       - "3100:3100"
@@ -159,7 +162,7 @@ services:
       - "./loki/loki.yaml:/etc/loki/loki.yaml"
 
   mimir:
-    image: grafana/mimir:2.12.0
+    image: grafana/mimir:2.13.0
     command: ["-ingester.native-histograms-ingestion-enabled=true", "-config.file=/etc/mimir.yaml"]
     ports:
       - "9009:9009"
@@ -179,13 +182,13 @@ services:
     command: ["run", "-o", "experimental-prometheus-rw", "/scripts/mythical-loadtest.js"]
 
   pyroscope:
-    image: grafana/pyroscope:1.5.0
+    image: grafana/pyroscope:1.7.1
     ports:
       - "4040:4040"
     command: ["server"]
 
   beyla-requester:
-    image: grafana/beyla:1.5.3
+    image: grafana/beyla:1.7.0
     # Beyla requires to be run in the same process namespace as the process it's watching.
     # In Docker, we can do this by joining the namespace for the watched process with the Beyla
     # container watching it by using a specific `pid` label.
@@ -222,7 +225,7 @@ services:
         condition: service_started
 
   beyla-server:
-    image: grafana/beyla:1.5.3
+    image: grafana/beyla:1.7.0
     # Beyla requires to be run in the same process namespace as the process it's watching.
     # In Docker, we can do this by joining the namespace for the watched process with the Beyla
     # container watching it by using a specific `pid` label.
@@ -259,7 +262,7 @@ services:
         condition: service_started
 
   beyla-recorder:
-    image: grafana/beyla:1.5.3
+    image: grafana/beyla:1.7.0
     # Beyla requires to be run in the same process namespace as the process it's watching.
     # In Docker, we can do this by joining the namespace for the watched process with the Beyla
     # container watching it by using a specific `pid` label.

--- a/source/mythical-beasts-requester/index.js
+++ b/source/mythical-beasts-requester/index.js
@@ -48,6 +48,12 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
     let headers = {};
     let error = false;
 
+    // This method is used to generate a time 40 minutes in the past for the logs.
+    let timeshift = () => {
+        var date = (process.env.TIMESHIFT) ? new Date(Date.now() - (1000 * 60 * 40)) : new Date(Date.now());
+        return date.toISOString();
+    }
+
     // Create a new span, link to previous request to show how linking between traces works.
     const requestSpan = tracer.startSpan('requester', {
         kind: api.SpanKind.CLIENT,
@@ -86,7 +92,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
                     job: `${servicePrefix}-requester`,
                     endpointLabel: spanTag,
                     endpoint,
-                    message: `traceID=${traceId} http.method=GET endpoint=${endpoint} status=SUCCESS`,
+                    message: `traceID=${traceId} http.method=GET endpoint=${endpoint} loggedtime=${timeshift()} status=SUCCESS`,
                 });
                 names = result.data;
 
@@ -103,7 +109,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
                             job: `${servicePrefix}-requester`,
                             endpointLabel: spanTag,
                             endpoint,
-                            message: `traceID=${traceId} http.method=DELETE endpoint=${endpoint} status=SUCCESS`,
+                            message: `traceID=${traceId} http.method=DELETE endpoint=${endpoint} loggedtime=${timeshift()} status=SUCCESS`,
                         });
                     }
                 }
@@ -115,7 +121,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
                     endpointLabel: spanTag,
                     endpoint,
                     message: `traceID=${traceId} http.method=DELETE endpoint=${endpoint} ` +
-                        `name=${(names) ? names[0].name : 'unknown'} status=FAILURE error="${err}"`,
+                        `name=${(names) ? names[0].name : 'unknown'} status=FAILURE loggedtime=${timeshift()}`,
                 });
                 error = true;
             }
@@ -132,7 +138,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
                     job: `${servicePrefix}-requester`,
                     endpointLabel: spanTag,
                     endpoint,
-                    message: `traceID=${traceId} http.method=POST endpoint=${endpoint} status=SUCCESS`,
+                    message: `traceID=${traceId} http.method=POST endpoint=${endpoint} loggedtime=${timeshift()} status=SUCCESS`,
                 });
             } catch (err) {
                 // The error condition is a little different here to using request. Axios throws a more generic error
@@ -145,7 +151,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
                     endpointLabel: spanTag,
                     endpoint,
                     message: `traceID=${traceId} http.method=POST endpoint=${endpoint} name=${randomName}` +
-                        ` status=FAILURE error="${err}"`,
+                        ` loggedtime=${timeshift()} status=FAILURE`,
                 });
                 error = true;
             }
@@ -157,7 +163,7 @@ const makeRequest = async (tracingObj, sendMessage, logEntry) => {
             job: `${servicePrefix}-requester`,
             endpointLabel: spanTag,
             endpoint,
-            message: `traceID=${traceId} http.method=${type} endpoint=${endpoint} duration=${Date.now() - start}ms`,
+            message: `traceID=${traceId} http.method=${type} endpoint=${endpoint} duration=${Date.now() - start}ms loggedtime=${timeshift()}`,
         });
 
         // Set the status code as OK and end the span


### PR DESCRIPTION
Also:
* Updates README to correct links.
* Adds a Loki processor to the Alloy config to use timestamps in loglines from mythical-requester.
* Adds a TIMESHIFT envvar to the Docker Compose manifest for mythical-requester, which allows the time for a log entry to be 40 minutes in the past (shows off above Alloy processor functionality).