### PR TITLE
Add workflows for auto-building and releasing the application images.

### DIFF
--- a/.github/workflows/publish-and-deploy-images.yaml
+++ b/.github/workflows/publish-and-deploy-images.yaml
@@ -1,0 +1,145 @@
+name: "Build and publish mythical images"
+on:
+    push:
+        branches:
+            - 'main'
+        paths:
+            - source/**
+
+    workflow_dispatch:
+        inputs:
+            push_images:
+                description: "Push images to registry"
+                default: false
+                required: true
+                type: boolean
+            version:
+                description: "The version used when tagging the image"
+                required: true
+                type: string
+
+    workflow_call:
+        inputs:
+            push_images:
+                description: "Push images to registry"
+                default: false
+                required: true
+                type: boolean
+            version:
+                description: "The version used when tagging the image"
+                required: true
+                type: string
+
+jobs:
+    build_and_push_images:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+
+        env:
+            REGISTRY_LOCATION: grafana/intro-to-mltp
+
+        strategy:
+            fail-fast: false
+            matrix:
+                file_tag:
+                    - file: source/docker/Dockerfile
+                      tag_suffix: mythical-beasts-requester
+                      context: source
+                      service: mythical-beasts-requester
+                      setup-qemu: true
+                    - file: source/docker/Dockerfile
+                      tag_suffix: mythical-beasts-server
+                      context: source
+                      service: mythical-beasts-server
+                      setup-qemu: true
+                    - file: source/docker/Dockerfile
+                      tag_suffix: mythical-beasts-recorder
+                      context: source
+                      service: mythical-beasts-recorder
+                      setup-qemu: true
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: DetermineReference
+              id: get_reference
+              run: |
+                if [ -z "$GITHUB_HEAD_REF" ]; then
+                  echo "ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
+                else
+                  echo "ref=$GITHUB_HEAD_REF" >> "$GITHUB_OUTPUT"
+                fi
+
+            - name: Determine image_tag to use
+              id: image_tag
+              run: |
+                SHA=$(git rev-parse --short HEAD)
+                BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '/' '__')
+                REF_TAG=${{ steps.get_reference.outputs.ref }}
+                INPUT_VERSION=${{ inputs.version }}
+
+                echo "SHA: $SHA"
+                echo "Branch: $BRANCH"
+                echo "Ref tag: $REF_TAG"
+                echo "Input Version: $INPUT_VERSION"
+
+                if [[ $INPUT_VERSION =~ refs\/(heads|tags)\/ ]]; then
+                    INPUT_VERSION=$(echo $INPUT_VERSION | cut -d "/" -f 3)
+                    echo "Tidied Input Version to remove 'refs/heads/'. New Input Version $INPUT_VERSION"
+                fi
+
+                if [[ $REF_TAG =~ refs\/(heads|tags)\/ ]]; then
+                    REF_TAG=$(echo $REF_TAG | cut -d "/" -f 3)
+                    echo "Shortened ref tag is $REF_TAG"
+                fi
+
+                if [ -z "$INPUT_VERSION" ]; then
+                    REF_TAG=$(echo -n "$REF_TAG" | tr -c '[:alnum:]._' '-')
+                    echo "version=$REF_TAG" >> "$GITHUB_OUTPUT"
+                    echo "Using version tag $REF_TAG"
+                else
+                    INPUT_VERSION=$(echo -n "$INPUT_VERSION" | tr -c '[:alnum:]._' '-')
+                    echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+                    echo "Using version tag $INPUT_VERSION"
+                fi
+
+                # Finally check to see if we're building on main; if we are, add a tag for latest.
+                if [ "$BRANCH" == "main" ]; then
+                    echo "latest_tag=${{env.REGISTRY_LOCATION}}:${{matrix.file_tag.tag_suffix}}-latest" >> "$GITHUB_OUTPUT"
+                fi
+
+            - name: Set up QEMU
+              if: ${{ matrix.file_tag.setup-qemu }}
+              uses: docker/setup-qemu-action@v3
+              with:
+                image: tonistiigi/binfmt:master
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+              with:
+                  config-inline: |
+                    [worker.oci]
+                    max-parallelism = 2
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Matrix Build and push Mythical images
+              uses: docker/build-push-action@v6
+              with:
+                context: ${{ matrix.file_tag.context }}
+                file: ${{ matrix.file_tag.file }}
+                build-args: |
+                  SERVICE=${{ matrix.file_tag.service }}
+                platforms: linux/amd64,linux/arm64
+                outputs: type=registry,push=${{inputs.push_images}}
+                tags: |
+                  ${{ env.REGISTRY_LOCATION }}:${{  matrix.file_tag.tag_suffix }}-${{ steps.image_tag.outputs.version }}
+                  ${{ steps.image_tag.outputs.latest_tag }}

--- a/.github/workflows/pull-request-build-images.yaml
+++ b/.github/workflows/pull-request-build-images.yaml
@@ -1,0 +1,19 @@
+name: "Build mythical images for PR"
+on:
+    pull_request:
+        types: [opened, synchronize]
+        paths:
+            - source/**
+
+jobs:
+    build_images:
+        name: "Build PR images"
+        permissions:
+            contents: read
+            packages: write
+
+        uses: ./.github/workflows/publish-and-deploy-images.yaml
+        with:
+            push_images: true
+            version: ${{ github.head_ref }}
+        secrets: inherit

--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -1,0 +1,23 @@
+name: "Release image versions for mythical"
+on:
+    release:
+        types: [published]
+
+    workflow_dispatch:
+        inputs:
+            version:
+                description: "The version to build and release"
+                required: true
+
+jobs:
+    build_images:
+        name: "Build versioned images"
+        permissions:
+            contents: read
+            packages: write
+
+        uses: ./.github/workflows/publish-and-deploy-images.yaml
+        with:
+            push_images: true
+            version: ${{ github.event.inputs.version || github.event.release.tag_name }}
+        secrets: inherit


### PR DESCRIPTION
* Builds on PR for image testing, with branch tags.
* Builds on PR merge with `latest` and `main` tags.
* Builds with version publishing to allow versioned tags.

Been meaning to do this for ages, and recent rebuild woes have forced my hand.