### PR TITLE
[chore] - Add Dependabot Configuration to Create PRs for Dependency Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/source/docker/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/source/mythical-beasts-recorder/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/source/mythical-beasts-requester/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/source/mythical-beasts-server/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps): "


### PR DESCRIPTION
Adds a Dependabot Configuration to create PRs to Bump Package Dependencies for Docker and NPM, and also Workflow Actions.

Once enabled, and initial PRs generated and merged, it would be good to trigger a (Minor) release if possible.