### PR TITLE
Allow specifying Mythical Database Connection Details and Credentials via Environment Variables

### DIFF
--- a/source/mythical-beasts-server/index.js
+++ b/source/mythical-beasts-server/index.js
@@ -429,7 +429,7 @@ const logUtils = require('./logging')('mythical-server', 'server');
         let databaseUser = "postgres"
         let databasePassword = "mythical"
         // check env var for overrides
-        if (process.env.MYTHICAL_DATABASE_HOST_) {
+        if (process.env.MYTHICAL_DATABASE_HOST) {
             databaseHost = process.env.MYTHICAL_DATABASE_HOST
         }
         if (process.env.MYTHICAL_DATABASE_HOST_PORT) {

--- a/source/mythical-beasts-server/index.js
+++ b/source/mythical-beasts-server/index.js
@@ -423,6 +423,25 @@ const logUtils = require('./logging')('mythical-server', 'server');
     // Create the DB and connect to it
     const startServer = async () => {
         const requestSpan = tracer.startSpan('server');
+
+        let databaseHost = "mythical-database"
+        let databaseHostPort = 5432
+        let databaseUser = "postgres"
+        let databasePassword = "mythical"
+        // check env var for overrides
+        if (process.env.MYTHICAL_DATABASE_HOST_) {
+            databaseHost = process.env.MYTHICAL_DATABASE_HOST
+        }
+        if (process.env.MYTHICAL_DATABASE_HOST_PORT) {
+            databaseHostPort = process.env.MYTHICAL_DATABASE_HOST_PORT
+        }
+        if (process.env.MYTHICAL_DATABASE_USER) {
+            databaseUser = process.env.MYTHICAL_DATABASE_USER
+        }
+        if (process.env.MYTHICAL_DATABASE_PASSWORD) {
+            databasePassword = process.env.MYTHICAL_DATABASE_PASSWORD
+        }
+
         // Create a new context for this request
         await api.context.with(api.trace.setSpan(api.context.active(), requestSpan), async () => {
             try {
@@ -433,10 +452,10 @@ const logUtils = require('./logging')('mythical-server', 'server');
                     message: 'Installing postgres client...',
                 });
                 pgClient = new Client({
-                    host: 'mythical-database',
-                    port: 5432,
-                    user: 'postgres',
-                    password: 'mythical',
+                    host: databaseHost,
+                    port: Number(databaseHostPort),
+                    user: databaseUser,
+                    password: databasePassword,
                 });
 
                 await pgClient.connect();

--- a/source/mythical-beasts-server/index.js
+++ b/source/mythical-beasts-server/index.js
@@ -424,24 +424,6 @@ const logUtils = require('./logging')('mythical-server', 'server');
     const startServer = async () => {
         const requestSpan = tracer.startSpan('server');
 
-        let databaseHost = "mythical-database"
-        let databaseHostPort = 5432
-        let databaseUser = "postgres"
-        let databasePassword = "mythical"
-        // check env var for overrides
-        if (process.env.MYTHICAL_DATABASE_HOST) {
-            databaseHost = process.env.MYTHICAL_DATABASE_HOST
-        }
-        if (process.env.MYTHICAL_DATABASE_HOST_PORT) {
-            databaseHostPort = process.env.MYTHICAL_DATABASE_HOST_PORT
-        }
-        if (process.env.MYTHICAL_DATABASE_USER) {
-            databaseUser = process.env.MYTHICAL_DATABASE_USER
-        }
-        if (process.env.MYTHICAL_DATABASE_PASSWORD) {
-            databasePassword = process.env.MYTHICAL_DATABASE_PASSWORD
-        }
-
         // Create a new context for this request
         await api.context.with(api.trace.setSpan(api.context.active(), requestSpan), async () => {
             try {
@@ -452,10 +434,10 @@ const logUtils = require('./logging')('mythical-server', 'server');
                     message: 'Installing postgres client...',
                 });
                 pgClient = new Client({
-                    host: databaseHost,
-                    port: Number(databaseHostPort),
-                    user: databaseUser,
-                    password: databasePassword,
+                    host: process.env.MYTHICAL_DATABASE_HOST ?? 'mythical-database',
+                    port: Number(process.env.MYTHICAL_DATABASE_HOST_PORT) ?? 5432,
+                    user: process.env.MYTHICAL_DATABASE_USER ?? 'postgres',
+                    password: process.env.MYTHICAL_DATABASE_PASSWORD ?? 'mythical',
                 });
 
                 await pgClient.connect();


### PR DESCRIPTION
This PR allows you to specify the Mythical Database Connection Details and Credentials via Environment Variables.

This allows you to set a custom Hostname, or Password for the Database Connection.