### PR TITLE
Update config.alloy

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -438,6 +438,17 @@ pyroscope.scrape "mythical" {
             path = "/debug/pprof/heap"
             delta = false
         }
+        // These profile scrapers are enabled by default, but the app has no endpoints for them to scrape.  This results in a bunch of 404 errors in the Alloy logs which makes troubleshooting more difficult.
+        // By disabling these scrapers, the Alloy logs are more readable.
+        profile.goroutine {
+            enabled = false
+        }
+        profile.block {
+            enabled = false
+        }
+        profile.mutex {
+            enabled = false
+        }
     }
 
     // Forward all scraped data to the Pyroscope exporter.


### PR DESCRIPTION
The goroutine, block, and mutex Pyroscope profile scrapers (among others) are enabled by default, even if there are no endpoints in any of the apps to be scraped.

For cases where the endpoints don't exist, we get a ton of 404 errors in the Alloy logs, which distract from other content.

This config change disables the scrapers with no endpoints, making the Alloy logs cleaner and operations a bit more efficient.