### PR TITLE
Add OTLP HTTP receiver and OTLP metrics pipeline.

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -167,9 +167,12 @@ loki.write "mythical" {
 otelcol.receiver.otlp "otlp_receiver" {
     // We don't technically need this, but it shows how to change listen address and incoming port.
     // In this case, the Alloy is listening on all available bindable addresses on port 4317 (which is the
-    // default OTLP gRPC port) for the OTLP protocol.
+    // default OTLP gRPC port) and port 4318 (which is the OTLP HTTP port) for the OTLP protocol.
     grpc {
         endpoint = "0.0.0.0:4317"
+    }
+    http {
+        endpoint = "0.0.0.0:4318"
     }
 
     // We define where to send the output of all ingested traces. In this case, to the OpenTelemetry batch processor
@@ -189,6 +192,10 @@ otelcol.receiver.otlp "otlp_receiver" {
             otelcol.processor.batch.default.input,
             otelcol.connector.spanlogs.autologging.input,
         ]
+        // Route any incoming OTLP metrics directly to the batch processor.
+        metrics = [
+            otelcol.processor.batch.default.input,
+        ]
     }
 }
 
@@ -200,9 +207,11 @@ otelcol.processor.batch "default" {
     send_batch_max_size = 2000
     // Or until 2 seconds have elapsed.
     timeout = "2s"
-    // When the Alloy has enough batched data, send it to the OpenTelemetry exporter named 'tempo'.
+    // When the Alloy has enough batched data, send it to the OpenTelemetry exporter named 'tempo' for traces,
+    // or the Prometheus exporter for metrics.
     output {
         traces = [otelcol.exporter.otlp.tempo.input]
+        metrics = [otelcol.exporter.prometheus.tracemetrics.input]
     }
 }
 

--- a/docker-compose-cloud.yml
+++ b/docker-compose-cloud.yml
@@ -13,6 +13,8 @@ services:
       - "12348:12348"
       - "6832:6832"
       - "55679:55679"
+      - "4317:4317"
+      - "4318:4318"
     volumes:
       - "./alloy/config.alloy:/etc/alloy/config.alloy"
       - "./alloy/endpoints-cloud.json:/etc/alloy/endpoints.json"

--- a/docker-compose-otel.yml
+++ b/docker-compose-otel.yml
@@ -11,6 +11,8 @@ services:
       - "12348:12348"
       - "6832:6832"
       - "55679:55679"
+      - "4317:4317"
+      - "4318:4318"
     volumes:
       - ./otel/otel.yml:/etc/otel-collector-config.yml
     command: ["--config=/etc/otel-collector-config.yml"]
@@ -130,7 +132,6 @@ services:
     image: grafana/tempo:2.6.0
     ports:
       - "3200:3200"
-      - "4317:4317"
       - "55680:55680"
       - "55681:55681"
       - "14250:14250"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - "12348:12348"
       - "6832:6832"
       - "55679:55679"
+      - "4317:4317"
+      - "4318:4318"
     volumes:
       - "./alloy/config.alloy:/etc/alloy/config.alloy"
       - "./alloy/endpoints.json:/etc/alloy/endpoints.json"
@@ -141,8 +143,6 @@ services:
     image: grafana/tempo:2.6.0
     ports:
       - "3200:3200"
-      - "4317:4317"
-      - "4318:4318"
       - "9411:9411"
       - "55680:55680"
       - "55681:55681"

--- a/otel/otel.yml
+++ b/otel/otel.yml
@@ -1,11 +1,13 @@
 # Define the protocols to receive data for.
 # See https://opentelemetry.io/docs/collector/configuration/#receivers
 receivers:
-  # Configure receiving OTLP data via gRPC on port 4317.
+  # Configure receiving OTLP data via gRPC on port 4317 and HTTP on port 4318.
   otlp:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
   # Defines a Prometheus configuration set.
   prometheus:
@@ -187,10 +189,10 @@ service:
     # Define the metrics pipeline.
     metrics:
       # Receive metrics from the `prometheus` receiver.
-      receivers: [prometheus]
+      receivers: [otlp, prometheus]
       # Comment out other `receivers` definitions and uncomment the line below to import spanmetrics as well
       # as prometheus metrics.
-      #receivers: [prometheus, spanmetrics]
+      #receivers: [otlp, prometheus, spanmetrics]
       # Use the `batch` processor to process received metrics.
       processors: [batch]
       # Export to the `prometheusremtotewrite` exporter.


### PR DESCRIPTION
Adds an OTLP HTTP endpoint to both Alloy and the
OpenTelemetry Collector, and includes changes to both configurations to output metrics in Prometheus format.