### PR TITLE
feat: Add Namespace Label/Tag to Profiles in Mythical Services

### DIFF
--- a/source/mythical-beasts-recorder/index.js
+++ b/source/mythical-beasts-recorder/index.js
@@ -25,6 +25,9 @@ app.get('/metrics', async (req, res) => {
 Pyroscope.init({
     serverAddress: `http://${process.env.PROFILE_COLLECTOR_HOST}:${process.env.PROFILE_COLLECTOR_PORT}`,
     appName: 'mythical-recorder',
+    tags: {
+        namespace: `${process.env.NAMESPACE ?? 'mythical'}`
+    },
 });
 Pyroscope.start();
 

--- a/source/mythical-beasts-requester/index.js
+++ b/source/mythical-beasts-requester/index.js
@@ -35,6 +35,9 @@ app.get('/metrics', async (req, res) => {
 Pyroscope.init({
     serverAddress: `http://${process.env.PROFILE_COLLECTOR_HOST}:${process.env.PROFILE_COLLECTOR_PORT}`,
     appName: 'mythical-requester',
+    tags: {
+        namespace: `${process.env.NAMESPACE ?? 'mythical'}`
+    },
 });
 Pyroscope.start();
 

--- a/source/mythical-beasts-server/index.js
+++ b/source/mythical-beasts-server/index.js
@@ -121,6 +121,9 @@ const logUtils = require('./logging')('mythical-server', 'server');
     Pyroscope.init({
         serverAddress: `http://${process.env.PROFILE_COLLECTOR_HOST}:${process.env.PROFILE_COLLECTOR_PORT}`,
         appName: 'mythical-server',
+        tags: {
+            namespace: `${process.env.NAMESPACE ?? 'mythical'}`
+        },
     });
     Pyroscope.start();
 


### PR DESCRIPTION
This PR adds a `namespace` Tag, to all Profiles from the Mythical Services (Recorder, Requester and Server) to set the Value to the Namespace Value from the Environment Variable (already defined and used elsewhere) and fallsback to `mythical` if its not set.