### PR TITLE
Use Vault for secrets

### DIFF
--- a/.github/workflows/publish-and-deploy-images.yaml
+++ b/.github/workflows/publish-and-deploy-images.yaml
@@ -16,7 +16,7 @@ jobs:
         permissions:
             contents: read
             packages: write
-
+            id-token: write
         env:
             REGISTRY_LOCATION: grafana/intro-to-mltp
 
@@ -93,11 +93,18 @@ jobs:
                     [worker.oci]
                     max-parallelism = 2
 
+            - id: get-secrets
+              uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+              with:
+                common_secrets: |
+                  DOCKERHUB_USERNAME=dockerhub:username
+                  DOCKERHUB_PASSWORD=dockerhub:password
+
             - name: Login to Docker Hub
               uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
               with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+                username: ${{ env.DOCKERHUB_USERNAME }}
+                password: ${{ env.DOCKERHUB_PASSWORD }}
 
             - name: Matrix Build and push Mythical images
               uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1


### PR DESCRIPTION
This updates our GHA workflow to use Vault as a secret store instead of GitHub Actions secrets.